### PR TITLE
feat: slotted social icons

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -62,14 +62,23 @@
           /* CSS tweaks escape hatch */
         </style>
       </template>
+
+      <!-- thought experiment: develop a template DSL for interpolations -->
+      <!-- OTOH, YAGNI -->
+      <!-- <template slot="social-link">
+        <div class="footer--social-links">
+          <a data-repeat href={{item.href}} class="footer--social-link">
+            <pfe-icon icon="web-icon-{{item.icon}}">{{item.content}}</pfe-icon>
+          </a>
+        </div>
+      </template> -->
+
       <h3 data-title slot="description">About Customer Portal</h3>
       <p slot="description">Cupidatat deserunt excepteur sit duis consectetur. Minim Lorem esse ullamco dolore dolor ad Lorem deserunt. Officia occaecat ullamco nisi exercitation.</p>
-      <ul slot="social-links">
-        <li data-icon="linkedin"><a href="#LinkedIn">LinkedIn</a></li>
-        <li data-icon="youtube"><a href="#Youtube">Youtube</a></li>
-        <li data-icon="facebook"><a href="#Facebook">Facebook</a></li>
-        <li data-icon="twitter"><a href="#Twitter">Twitter</a></li>
-      </ul>
+      <li slot="social" data-icon="linkedin"><a href="#LinkedIn">LinkedIn</a></li>
+      <li slot="social" data-icon="youtube"><a href="#Youtube">Youtube</a></li>
+      <li slot="social" data-icon="facebook"><a href="#Facebook">Facebook</a></li>
+      <li slot="social" data-icon="twitter"><a href="#Twitter">Twitter</a></li>
       <div slot="links">
         <h3 data-header>Products</h3>
         <ul>

--- a/src/RhFooter.js
+++ b/src/RhFooter.js
@@ -327,7 +327,7 @@ export class RhFooter extends LitElement {
       });
     const title = description.find(i => i.hasAttribute('data-title'));
     const paragraphs = description.filter(i => i !== title);
-    this.description = Object.assign({ title, paragraphs });
+    this.description = {title, paragraphs};
   }
 
   renderLogo() {
@@ -347,6 +347,25 @@ export class RhFooter extends LitElement {
     `;
   }
 
+  /**
+   * Imperatively generate icons _in light DOM_ from light-DOM data attrs
+   * other approaches considered:
+   *   - get svg icon url from pfe-icon config and use as a background in css
+   */
+  onMutation() {
+    // is the MO observing childList? infinite loop - maybe just do it in slotchange
+    for (const link of this.querySelector('[slot="social"]')) {
+      const icon = document.createElement("pfe-icon");
+      icon.icon = link.dataset.icon;
+      link.prependChild(icon);
+    }
+  }
+
+  // NOTES: WRT render props, probably YAGNI, and they increase the API surface significantly.
+  // alternatively, put the default templates in the 'big template' in render, for readability,
+  // but just check for the existence of the render prop first
+  // recommend passing `this` as the argument to renderprop functions
+  
   renderSocialLinks(socialLinks) {
     return html`
       <div class="footer--social-links">


### PR DESCRIPTION
## Q&A
- Q: why new repo instead of PR
    - A: waiting on powers to get template repos together
- Q: How'd you set up tools for that repo
    - A: `npm init @open-wc`
- Q: What sucked about that?
    - A: no tooling parity with pfe
        - npm script names
        - no esbuild like from patternfly lit
- Q: what was great about that?
    - A: yeah it was ok i guess
- Q: no ts?
    - A: npm init open-wc failed on typescript init
    - Powers should check into this. Potter please link to issue if you can
- Q: what's the advantage of data- attrs to copy content over just slots?
    - A: generating content, even in slotted elements
