### PR TITLE
Blocks

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,6 +116,15 @@
       </rh-footer>
     </section>
 
+    <section>
+      <h2>Custom links</h2>
+      <rh-footer>
+        <rh-footer-block slot="main__secondary">
+          <h3 slot="header">About Red Hat</h3>
+          <p>We’re the world’s leading provider of enterprise open source solutions―including Linux, cloud, container, and Kubernetes. We deliver hardened solutions that make it easier for enterprises to work across platforms and environments, from the core datacenter to the network edge.</p>
+        </rh-footer-block>
+      </rh-footer>
+    </section>
 
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -116,12 +116,20 @@
       </rh-footer>
     </section>
 
-    <section>
-      <h2>Custom links</h2>
+    <section id="blocks">
+      <h2>Blocks</h2>
       <rh-footer>
-        <rh-footer-block slot="main__secondary">
+        <rh-footer-block slot="main__secondary" class="first">
           <h3 slot="header">About Red Hat</h3>
           <p>We’re the world’s leading provider of enterprise open source solutions―including Linux, cloud, container, and Kubernetes. We deliver hardened solutions that make it easier for enterprises to work across platforms and environments, from the core datacenter to the network edge.</p>
+        </rh-footer-block>
+        <rh-footer-block slot="main__secondary">
+          <h3 slot="header">Subscribe to our free newsletter, Red Hat Shares</h3>
+          <pfe-cta><a href="#blocks">Sign up now</a></pfe-cta>
+        </rh-footer-block>
+        <rh-footer-block slot="main__secondary" class="last">
+          <h3 slot="header">Select a language</h3>
+          <p>insert language switcher here...</p>
         </rh-footer-block>
       </rh-footer>
     </section>

--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
     <section id="blocks">
       <h2>Blocks</h2>
       <rh-footer>
-        <rh-footer-block slot="main__secondary" class="first">
+        <rh-footer-block slot="main__secondary">
           <h3 slot="header">About Red Hat</h3>
           <p>We’re the world’s leading provider of enterprise open source solutions―including Linux, cloud, container, and Kubernetes. We deliver hardened solutions that make it easier for enterprises to work across platforms and environments, from the core datacenter to the network edge.</p>
         </rh-footer-block>
@@ -127,7 +127,7 @@
           <h3 slot="header">Subscribe to our free newsletter, Red Hat Shares</h3>
           <pfe-cta><a href="#blocks">Sign up now</a></pfe-cta>
         </rh-footer-block>
-        <rh-footer-block slot="main__secondary" class="last">
+        <rh-footer-block slot="main__secondary">
           <h3 slot="header">Select a language</h3>
           <p>insert language switcher here...</p>
         </rh-footer-block>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "rh-footer",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rh-footer",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "license": "MIT",
       "dependencies": {
-        "@patternfly/pfe-accordion": "^1.12.2",
-        "@patternfly/pfe-cta": "^1.12.2",
-        "@patternfly/pfe-icon": "^1.12.2",
+        "@patternfly/pfe-accordion": "^1.12.3",
+        "@patternfly/pfe-cta": "^1.12.3",
+        "@patternfly/pfe-icon": "^1.12.3",
+        "@patternfly/pfe-styles": "^1.12.3",
         "lit": "^2.0.2"
       },
       "devDependencies": {
@@ -2082,33 +2083,38 @@
       }
     },
     "node_modules/@patternfly/pfe-accordion": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@patternfly/pfe-accordion/-/pfe-accordion-1.12.2.tgz",
-      "integrity": "sha512-JwEb9IvBBqkmKfpSH+WU2GN1NEYHphXTiCuEyJo3WPtBZ2enwHhOG/9ZfqWjTtV0JvaDjjwWLRKDjG8pRZ3PTw==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/@patternfly/pfe-accordion/-/pfe-accordion-1.12.3.tgz",
+      "integrity": "sha512-pVAhrAKAfa402WpSj14ihcO8hvPsBlANatFu+t+3WkL7bWkQ0XsoZM2RQXnBuzMkuFcccwjzP2B2eYQJnQpa2w==",
       "dependencies": {
-        "@patternfly/pfelement": "^1.12.2"
+        "@patternfly/pfelement": "^1.12.3"
       }
     },
     "node_modules/@patternfly/pfe-cta": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@patternfly/pfe-cta/-/pfe-cta-1.12.2.tgz",
-      "integrity": "sha512-YjOBL8M8C5c4raVLRL46akbjbmQbBa3jGsZ83ZEi1/iYU9ydEAgURJ4m/5+qRofA4zVd7G76guyUMYmBQ0Uz+Q==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/@patternfly/pfe-cta/-/pfe-cta-1.12.3.tgz",
+      "integrity": "sha512-4VSQETElAXa5Oodvng2RNKuHVXVrQ20PBBRJJQ72UZTc5tQkIaC2HCUuUxOIwVn3OGrerN/sO/JZll3ehedQmA==",
       "dependencies": {
-        "@patternfly/pfelement": "^1.12.2"
+        "@patternfly/pfelement": "^1.12.3"
       }
     },
     "node_modules/@patternfly/pfe-icon": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@patternfly/pfe-icon/-/pfe-icon-1.12.2.tgz",
-      "integrity": "sha512-ZrszdouuLo2Y2W+37LzOxubEN5rZSQgHMfENSm3daG4wfRoydlLMIjzF4bQIO7Xj1B6XiwLdbZF5W7Ea3d7jKw==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/@patternfly/pfe-icon/-/pfe-icon-1.12.3.tgz",
+      "integrity": "sha512-FftlKGp+FmpfJUEKS6UXh9SvRuytzue/RYon5zw9Hp+g7FV7W2hxIsrAcFvm7xLdosyC6rUBtHRO8+6niVT4QQ==",
       "dependencies": {
-        "@patternfly/pfelement": "^1.12.2"
+        "@patternfly/pfelement": "^1.12.3"
       }
     },
+    "node_modules/@patternfly/pfe-styles": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/@patternfly/pfe-styles/-/pfe-styles-1.12.3.tgz",
+      "integrity": "sha512-yFrOlh1/GfnBfF+DypfQ+GuJ83zI17nW73YfVfKtGjHwK7fdAEQKVW5YXmbIjqyV4ZQYA9czabXBW87dL2cNOg=="
+    },
     "node_modules/@patternfly/pfelement": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@patternfly/pfelement/-/pfelement-1.12.2.tgz",
-      "integrity": "sha512-oZKpqb0qS4kv1H+4YnSxpg9l5ZAsaWqTPRJ8eTFwBj8jvVPGhT6tj0NXo9O0v6g3ea0i7hw/aAjf9VNlixXp4w=="
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/@patternfly/pfelement/-/pfelement-1.12.3.tgz",
+      "integrity": "sha512-qBkZZpr0WTJ+ZovianRmsq8ScGxUVJOQccrfE7KKtn8E2cLrVaWvLqQQi/jWqpB7z+vgvL/aP8xhz0TAYg3AjA=="
     },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.0",
@@ -14175,33 +14181,38 @@
       }
     },
     "@patternfly/pfe-accordion": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@patternfly/pfe-accordion/-/pfe-accordion-1.12.2.tgz",
-      "integrity": "sha512-JwEb9IvBBqkmKfpSH+WU2GN1NEYHphXTiCuEyJo3WPtBZ2enwHhOG/9ZfqWjTtV0JvaDjjwWLRKDjG8pRZ3PTw==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/@patternfly/pfe-accordion/-/pfe-accordion-1.12.3.tgz",
+      "integrity": "sha512-pVAhrAKAfa402WpSj14ihcO8hvPsBlANatFu+t+3WkL7bWkQ0XsoZM2RQXnBuzMkuFcccwjzP2B2eYQJnQpa2w==",
       "requires": {
-        "@patternfly/pfelement": "^1.12.2"
+        "@patternfly/pfelement": "^1.12.3"
       }
     },
     "@patternfly/pfe-cta": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@patternfly/pfe-cta/-/pfe-cta-1.12.2.tgz",
-      "integrity": "sha512-YjOBL8M8C5c4raVLRL46akbjbmQbBa3jGsZ83ZEi1/iYU9ydEAgURJ4m/5+qRofA4zVd7G76guyUMYmBQ0Uz+Q==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/@patternfly/pfe-cta/-/pfe-cta-1.12.3.tgz",
+      "integrity": "sha512-4VSQETElAXa5Oodvng2RNKuHVXVrQ20PBBRJJQ72UZTc5tQkIaC2HCUuUxOIwVn3OGrerN/sO/JZll3ehedQmA==",
       "requires": {
-        "@patternfly/pfelement": "^1.12.2"
+        "@patternfly/pfelement": "^1.12.3"
       }
     },
     "@patternfly/pfe-icon": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@patternfly/pfe-icon/-/pfe-icon-1.12.2.tgz",
-      "integrity": "sha512-ZrszdouuLo2Y2W+37LzOxubEN5rZSQgHMfENSm3daG4wfRoydlLMIjzF4bQIO7Xj1B6XiwLdbZF5W7Ea3d7jKw==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/@patternfly/pfe-icon/-/pfe-icon-1.12.3.tgz",
+      "integrity": "sha512-FftlKGp+FmpfJUEKS6UXh9SvRuytzue/RYon5zw9Hp+g7FV7W2hxIsrAcFvm7xLdosyC6rUBtHRO8+6niVT4QQ==",
       "requires": {
-        "@patternfly/pfelement": "^1.12.2"
+        "@patternfly/pfelement": "^1.12.3"
       }
     },
+    "@patternfly/pfe-styles": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/@patternfly/pfe-styles/-/pfe-styles-1.12.3.tgz",
+      "integrity": "sha512-yFrOlh1/GfnBfF+DypfQ+GuJ83zI17nW73YfVfKtGjHwK7fdAEQKVW5YXmbIjqyV4ZQYA9czabXBW87dL2cNOg=="
+    },
     "@patternfly/pfelement": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@patternfly/pfelement/-/pfelement-1.12.2.tgz",
-      "integrity": "sha512-oZKpqb0qS4kv1H+4YnSxpg9l5ZAsaWqTPRJ8eTFwBj8jvVPGhT6tj0NXo9O0v6g3ea0i7hw/aAjf9VNlixXp4w=="
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/@patternfly/pfelement/-/pfelement-1.12.3.tgz",
+      "integrity": "sha512-qBkZZpr0WTJ+ZovianRmsq8ScGxUVJOQccrfE7KKtn8E2cLrVaWvLqQQi/jWqpB7z+vgvL/aP8xhz0TAYg3AjA=="
     },
     "@rollup/plugin-babel": {
       "version": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,10 @@
   },
   "dependencies": {
     "lit": "^2.0.2",
-    "@patternfly/pfe-accordion": "^1.12.2",
-    "@patternfly/pfe-cta": "^1.12.2",
-    "@patternfly/pfe-icon": "^1.12.2"
+    "@patternfly/pfe-accordion": "^1.12.3",
+    "@patternfly/pfe-cta": "^1.12.3",
+    "@patternfly/pfe-icon": "^1.12.3",
+    "@patternfly/pfe-styles": "^1.12.3"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.16.4",

--- a/src/RhFooter.ts
+++ b/src/RhFooter.ts
@@ -8,6 +8,7 @@ import './rh-footer-social-link.js';
 import './rh-footer-links.js';
 import './rh-footer-link.js';
 import './rh-footer-links-mobile.js';
+import './rh-footer-block.js';
 
 export class RhFooter extends LitElement {
 
@@ -17,6 +18,7 @@ export class RhFooter extends LitElement {
         :host {
           --_border-color: var(--rh-footer-border-color, #6A6E73);
           --_accent-color: var(--rh-footer-accent-color,  #ee0000);
+          --_section-side-gap: var(--rh-footer-section-side-gap,  var(--pf-global--spacer--lg, 24px));
           /* apply sensible defaults based on redhat standards. */
           color: #fff;
           font-family: "Red Hat Text", "RedHatText", "Overpass", Overpass, Arial, sans-serif;
@@ -59,7 +61,7 @@ export class RhFooter extends LitElement {
          * Regions
          */
         .section {
-          padding: var(--pf-global--spacer--xl, 32px) var(--pf-global--spacer--lg, 24px);
+          padding: var(--pf-global--spacer--xl, 32px) var(--_section-side-gap);
         }
 
         .header {
@@ -68,8 +70,19 @@ export class RhFooter extends LitElement {
           display: flex;
           flex-wrap: wrap;
           gap: var(--pf-global--spacer--xl, 32px);
-          border-bottom: 1px solid var(--_border-color);
           align-items: center;
+          position: relative;
+        }
+
+        .header::after {
+          display: block;
+          content: "";
+          background-color: var(--_border-color);
+          height: 1px;
+          position: absolute;
+          bottom: 0px;
+          width: calc(100% - var(--_section-side-gap) * 2);
+          left: var(--_section-side-gap);
         }
 
         .header__primary {
@@ -134,7 +147,7 @@ export class RhFooter extends LitElement {
         @media screen and (min-width: ${mobileXlBreakpoint}) {
           /* Equalize padding on mobile */
           .section {
-            padding: var(--pf-global--spacer--xl, 32px);
+            --_section-side-gap: var(--rh-footer-section-side-gap,  var(--pf-global--spacer--xl, 32px));
           }
 
           .header, .main {

--- a/src/RhFooter.ts
+++ b/src/RhFooter.ts
@@ -22,6 +22,7 @@ export class RhFooter extends LitElement {
           font-family: "Red Hat Text", "RedHatText", "Overpass", Overpass, Arial, sans-serif;
           line-height: 1.5;
           font-weight: 300;
+          /* set at 18px for margin and padding standardization */
           font-size: 18px;
 
           display: flex;

--- a/src/rh-footer-block.ts
+++ b/src/rh-footer-block.ts
@@ -1,0 +1,61 @@
+import {html, css, LitElement} from 'lit';
+
+export class RhFooterBlock extends LitElement {
+	static get tag() {
+		return 'rh-footer-block';
+	}
+
+	static get styles() {
+		return css`
+			:host {
+				display: block;
+				position: relative;
+			}
+
+			/** Add margin to blocks that aren't first in the sidebar. */
+			:host(:not(.first)) {
+				margin-top: 1.5em;
+			}
+
+			/** Add the separator to blocks in the middle */
+			:host(:not(.last, .first)) {
+				border-bottom: 1px solid var(--_border-color);
+				padding-bottom: 1.5em;
+			}
+
+			::slotted(*) {
+				color: #fff;
+				font-size: 14px;
+				text-decoration: none;
+			}
+
+			::slotted(:is(h1,h2,h3,h4,h5)) {
+				font-weight: 500;
+				font-size: 14px;
+				margin-top: 0px;
+			}
+
+		  .content ::slotted(*) {
+				color: #D2D2D2;
+				font-size: 0.875rem;
+				font-family: "Red Hat Text", "RedHatText", "Overpass", Overpass, Arial, sans-serif;
+				font-weight: 400;
+			}
+		`;
+	}
+
+	constructor() {
+		super();
+	}
+
+	render() {
+		return html`
+			<div class="base" part="base">
+				<div class="header" part="header"><slot name="header"></slot></div>
+				<div class="content" part="content"><slot></slot></div>
+			</div>
+		`;
+	}
+}
+
+customElements.define(RhFooterBlock.tag, RhFooterBlock);

--- a/src/rh-footer-block.ts
+++ b/src/rh-footer-block.ts
@@ -12,16 +12,15 @@ export class RhFooterBlock extends LitElement {
 				position: relative;
 			}
 
-			/** Add margin to blocks that aren't first in the sidebar. */
-			:host(:not(.first)) {
-				margin-top: 1.5em;
-			}
-
-			/** Add the separator to blocks in the middle */
-			:host(:not(.last, .first)) {
+      /** Add margin to blocks that aren't first in the sidebar. */
+      :host(:not(:first-of-type)) {
+        margin-top: 1.5em;
+      }
+      /** Add the separator to blocks in the middle */
+      :host(:not(:last-of-type, :first-of-type)){
 				border-bottom: 1px solid var(--_border-color);
 				padding-bottom: 1.5em;
-			}
+      }
 
 			::slotted(*) {
 				color: #fff;


### PR DESCRIPTION
Adds the ability to place "blocks" in the footer.  Namely, in the `main__secondary` slot.

![Screen Shot 2022-03-04 at 2 33 18 PM](https://user-images.githubusercontent.com/3428964/156831594-5d538adb-aa18-405f-ad5f-289752de5e65.png)

![Screen Shot 2022-03-04 at 2 48 10 PM](https://user-images.githubusercontent.com/3428964/156831671-a6d394b5-e1bb-411b-9c5b-8a66da88b290.png)

## Markup

```html
<rh-footer>
  <rh-footer-block slot="main__secondary" class="first">
    <h3 slot="header">About Red Hat</h3>
    <p>We’re the world’s leading provider of enterprise open source solutions―including Linux, cloud, container, and Kubernetes. We deliver hardened solutions that make it easier for enterprises to work across platforms and environments, from the core datacenter to the network edge.</p>
  </rh-footer-block>
  <rh-footer-block slot="main__secondary">
    <h3 slot="header">Subscribe to our free newsletter, Red Hat Shares</h3>
    <pfe-cta><a href="#blocks">Sign up now</a></pfe-cta>
  </rh-footer-block>
  <rh-footer-block slot="main__secondary" class="last">
    <h3 slot="header">Select a language</h3>
    <p>insert language switcher here...</p>
  </rh-footer-block>
</rh-footer>
```